### PR TITLE
Add Dockerfile for containerized execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3-slim
 ENV GRPC_LOCATION=127.0.0.1:10009
 ENV LND_DIR=~/.lnd
 
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
 WORKDIR /app/
 
 COPY requirements.txt .
@@ -11,4 +14,4 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-ENTRYPOINT /app/rebalance.py --grpc ${GRPC_LOCATION} --lnddir ${LND_DIR} "$@"
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-ENTRYPOINT /app/rebalance.py --grpc ${GRPC_LOCATION} --lnddir ${LND_DIR}
+ENTRYPOINT /app/rebalance.py --grpc ${GRPC_LOCATION} --lnddir ${LND_DIR} "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3-slim
+
+ENV GRPC_LOCATION=127.0.0.1:10009
+ENV LND_DIR=~/.lnd
+
+WORKDIR /app/
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT /app/rebalance.py --grpc ${GRPC_LOCATION} --lnddir ${LND_DIR}

--- a/README.md
+++ b/README.md
@@ -143,6 +143,21 @@ For example, the following command tries to sends 20% of the amount required to 
 
 The maximum amount you can send in one transaction currently is limited (by the protocol) to 4,294,967 satoshis.
 
+## Docker
+
+You can build this repository and provide the LND directory & LND RPC location through environment variables. Example for Docker Compose:
+
+```yaml
+  rebalance-lnd:
+    build: https://github.com/accumulator/rebalance-lnd.git
+    environment:
+      - GRPC_LOCATION=lnd:10009
+      - LND_DIR=/lnd
+    user: 1000 # example
+    volumes:
+      - /path/to/lnd:/lnd:ro
+```
+
 ## Contributing
 
 Contributions are highly welcome!

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec /app/rebalance.py --grpc "${GRPC_LOCATION}" --lnddir "${LND_DIR}" "$@"


### PR DESCRIPTION
This PR will add a Dockerfile to the project. This allows users that have their Bitcoin/LND stack containerized, to plug in rebalance-lnd with a bit less effort than it currently takes. 