### PR TITLE
Exclude nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ rebalance:
                         in the incoming candidate list (-l -i).
   -e EXCLUDE, --exclude EXCLUDE
                         Exclude the given channel ID in route finding.
+  -E EXCLUDENODE, --excludenode EXCLUDENODE
+                        Exclude the given node ID in route finding.
   -F MAX_FEE_FACTOR, --max-fee-factor MAX_FEE_FACTOR
                         (default: 10) Reject routes that cost more than x
                         times the lnd default (base: 1 sat, rate: 1 millionth

--- a/fmt.py
+++ b/fmt.py
@@ -23,6 +23,9 @@ def parse_channel_id(s):
         return int(x_to_lnd_scid(s))
     return int(s)
 
+def parse_node_id(s):
+    return bytes.fromhex(s)
+
 def print_route(route, lnd):
     route_str = ""
     for i in range(0,len(route.hops)):

--- a/logic.py
+++ b/logic.py
@@ -15,15 +15,19 @@ def debugnobreak(message):
     sys.stderr.write(message)
 
 class Logic:
-    def __init__(self, lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded, max_fee_factor, deep, path):
+    def __init__(self, lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded_channels,
+            excluded_nodes, max_fee_factor, deep, path):
         self.lnd = lnd
         self.first_hop_channel = first_hop_channel
         self.last_hop_channel = last_hop_channel
         self.amount = amount
         self.channel_ratio = channel_ratio
-        self.excluded = []
-        if excluded:
-            self.excluded = excluded
+        self.excluded_channels = []
+        self.excluded_nodes = []
+        if excluded_channels:
+            self.excluded_channels = excluded_channels
+        if excluded_nodes:
+            self.excluded_nodes = excluded_nodes
         self.max_fee_factor = max_fee_factor
         self.deep = deep
         self.path = path
@@ -60,6 +64,7 @@ class Logic:
 
         else:
             routes = Routes(self.lnd, payment_request, self.first_hop_channel, self.last_hop_channel, self.deep)
+            routes.ignored_nodes = self.excluded_nodes
 
             self.initialize_ignored_channels(routes)
 
@@ -178,7 +183,7 @@ class Logic:
         for channel in self.lnd.get_channels():
             if self.low_local_ratio_after_sending(channel, self.amount):
                 routes.ignore_first_hop(channel, show_message=False)
-            if channel.chan_id in self.excluded:
+            if channel.chan_id in self.excluded_channels:
                 debugnobreak("Channel is excluded, ")
                 routes.ignore_first_hop(channel)
             if not self.last_hop_channel:

--- a/rebalance.py
+++ b/rebalance.py
@@ -105,13 +105,18 @@ def main():
 
     max_fee_factor = arguments.max_fee_factor
 
-    excluded = []
+    excluded_channels = []
     if arguments.exclude:
-        for exclude in arguments.exclude:
-            excluded.append(fmt.parse_channel_id(exclude))
+        for chan_id in arguments.exclude:
+            excluded_channels.append(fmt.parse_channel_id(chan_id))
 
-    result = Logic(lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded,
-                 max_fee_factor, arguments.deep, hops).rebalance()
+    excluded_nodes = []
+    if arguments.excludenode:
+        for node_id in arguments.excludenode:
+            excluded_nodes.append(fmt.parse_node_id(node_id))
+
+    result = Logic(lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded_channels,
+                 excluded_nodes, max_fee_factor, arguments.deep, hops).rebalance()
 
     if not result:
         sys.exit(2)
@@ -204,6 +209,9 @@ def get_argument_parser():
     rebalance_group.add_argument("-e", "--exclude",
                                  action="append",
                                  help="Exclude the given channel ID in route finding.")
+    rebalance_group.add_argument("-E", "--excludenode",
+                                 action="append",
+                                 help="Exclude the given node ID in route finding.")
     rebalance_group.add_argument("-F", "--max-fee-factor",
                                  type=float,
                                  default=10,


### PR DESCRIPTION
There are some bad nodes on the network that fail routing 99% of the time (gameb, tippin.me etc.), they're unbalanced and/or abandoned so using them is a loss of time. This new parameter allows to ignore them during path finding and save time.