### PR TITLE
Separate from-to ratios

### DIFF
--- a/lnd.py
+++ b/lnd.py
@@ -79,6 +79,7 @@ class Lnd:
         if self.channels is None:
             request = ln.ListChannelsRequest(
                 active_only=True,
+                public_only=True,
             )
             self.channels = self.stub.ListChannels(request).channels
         return self.channels

--- a/logic.py
+++ b/logic.py
@@ -17,13 +17,14 @@ def debugnobreak(message):
     sys.stderr.write(message)
 
 class Logic:
-    def __init__(self, lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded_channels,
-            excluded_nodes, max_fee_factor, deep, path):
+    def __init__(self, lnd, first_hop_channel, last_hop_channel, amount, channel_ratio_to, channel_ratio_from,
+            excluded_channels, excluded_nodes, max_fee_factor, deep, path):
         self.lnd = lnd
         self.first_hop_channel = first_hop_channel
         self.last_hop_channel = last_hop_channel
         self.amount = amount
-        self.channel_ratio = channel_ratio
+        self.channel_ratio_to = channel_ratio_to
+        self.channel_ratio_from = channel_ratio_from
         self.excluded_channels = []
         self.excluded_nodes = []
         if excluded_channels:
@@ -42,8 +43,10 @@ class Logic:
                    % fmt.col_lo(fmt.print_chanid(self.last_hop_channel.chan_id)))
         else:
             debug("Ⓘ Sending " + fmt.col_hi("{:,}".format(self.amount)) + " satoshis.")
-        if self.channel_ratio != 0.5:
-            debug("Ⓘ Channel ratio used is " + fmt.col_hi("%d%%" % int(self.channel_ratio * 100)))
+        if self.channel_ratio_to != 0.5:
+            debug("Ⓘ Incoming channel ratio used is " + fmt.col_hi("%d%%" % int(self.channel_ratio_to * 100)))
+        if self.channel_ratio_from != 0.5:
+            debug("Ⓘ Outgoing channel ratio used is " + fmt.col_hi("%d%%" % int(self.channel_ratio_from * 100)))
         if self.first_hop_channel:
             debug("Ⓘ Forced first channel has ID %s" % fmt.col_lo(fmt.print_chanid(self.first_hop_channel.chan_id)))
 
@@ -173,7 +176,7 @@ class Logic:
         remote = channel.remote_balance + total_amount
         local = channel.local_balance - total_amount
         ratio = float(local) / (remote + local)
-        return ratio < self.channel_ratio
+        return ratio < (1 - self.channel_ratio_from)
 
     def fees_too_high(self, route):
         hops_with_fees = len(route.hops) - 1
@@ -208,5 +211,5 @@ class Logic:
                 remote = channel.remote_balance - self.amount
                 local = channel.local_balance + self.amount
                 ratio = float(local) / (remote + local)
-                if ratio > self.channel_ratio:
+                if ratio > self.channel_ratio_to:
                     routes.ignore_edge_from_to(channel.chan_id, channel.remote_pubkey, self.my_pubkey, show_message=False)


### PR DESCRIPTION
This PR adds equal treatment for `-f` flag allowing to specify the `from` channel by its index, but most importantly it adds separate `from` and `to` ratios. The use case is as follow:
- often the channel capacities are vastly different, you might have one channel at 95% and want to balance it down to 80% and you have some much bigger channel at 40%
- after this rebalance the bigger channel's balance would only become 45% so it's totally fine
- the current `-r` parameter allows to exclude slightly unbalanced channels and only consider those at their limit but it's applied to both source and target channels which is not always desired
- in the situation described above if we use `-r 20` the big channel with 40% outbound liquidity wouldn't even be considered even though it can safely accept those 15% from a smaller channel and still be balanced

Since there's probably no universal solution that fits everyone I propose to specify the desired inbound/outbound ratio explicitly. If you run rebalancing automatically you can use these new flags as follow:
- `rebalance.py -f 1 --ratio-from 20` — would choose the first channel with less than 20% inbound liquidity and pick any target channel with less than 50% outbound liquidity (that can accept the amount without becoming unbalanced of course)
- `rebalance.py -t 1 --ratio-to 20` — would choose the first channel with less than 20% outbound liquidity and pick any source channel with less than 50% inbound liquidity
- `rebalance.py -t 1 --ratio-to 20 --ratio-from 20` — would choose the first channel with less than 20% outbound liquidity and pick any source channel with less than 20% inbound liquidity (same as `-r 20`)

Since by default the ratio is 50%, you only need to set the ratio for the direction you're interested in. But in some cases you might also limit the target channel set to shift the balance to the starving channels first. It all depends on the use case. The `-r` behavior is unchanged, it sets both `--ratio-to` and `--ratio-from` to the specified value.

PS: I also added `public_only=True` to the channel filter so that private channels are not used at all. By definition they can't (and should not) be balanced as they're client's channels.