### PR TITLE
Add stats CSV output

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -1,6 +1,8 @@
 import sys
 
 import fmt
+import os
+import time
 from routes import Routes
 
 DEFAULT_BASE_FEE_SAT_MSAT = 1000
@@ -32,6 +34,7 @@ class Logic:
         self.deep = deep
         self.path = path
         self.my_pubkey = self.lnd.get_own_pubkey()
+        self.stat_filename = None
 
     def rebalance(self):
         if self.last_hop_channel:
@@ -95,6 +98,21 @@ class Logic:
             debug(fmt.col_hi("✔ Success!") + " Paid fees: %s sat (%s msat)" % 
                 (fmt.col_hi(route.total_fees), route.total_fees_msat))
             debug("")
+            if self.stat_filename:
+                try:
+                    add_header = not os.path.isfile(self.stat_filename)
+                    with open(self.stat_filename, mode="a") as f:
+                        if add_header:
+                            f.write("timestamp,from_channel,to_channel,amount_msat,fees_msat\n")
+                        f.write("%d,%d,%d,%d,%d\n" % (
+                            int(time.time()),
+                            route.hops[0].chan_id,
+                            route.hops[-1].chan_id,
+                            route.total_amt_msat - route.total_fees_msat,
+                            route.total_fees_msat
+                            ))
+                except e:
+                    debug(fmt.col_err("✘ Error writing the stat file: %s" % e))
             return True
         else:
             self.handle_error(response, route, routes)

--- a/rebalance.py
+++ b/rebalance.py
@@ -115,8 +115,12 @@ def main():
         for node_id in arguments.excludenode:
             excluded_nodes.append(fmt.parse_node_id(node_id))
 
-    result = Logic(lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded_channels,
-                 excluded_nodes, max_fee_factor, arguments.deep, hops).rebalance()
+    logic = Logic(lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded_channels,
+                 excluded_nodes, max_fee_factor, arguments.deep, hops)
+    if arguments.stat:
+        logic.stat_filename = arguments.stat
+
+    result = logic.rebalance()
 
     if not result:
         sys.exit(2)
@@ -224,6 +228,9 @@ def get_argument_parser():
     rebalance_group.add_argument("--path",
                                  action="append",
                                  help="Specify the route as a list of pubkeys. Optionally specify --from channel. --to is ignored.")
+    rebalance_group.add_argument("-s", "--stat",
+                                 type=str,
+                                 help="Save rebalancing statistics to a CSV file")
 
     amount_group = rebalance_group.add_mutually_exclusive_group()
     amount_group.add_argument("-a", "--amount",


### PR DESCRIPTION
This PR adds the option for writing the rebalance statistics to a CSV file. Currently LN isn't much profitable (if at all) but it's nice to be able to track your rebalancing expenses and compare them to the fees you earn. There are many tools already that can help with the latter (RTL, suez) but rebalancing fees aren't stored anywhere. It should also help to estimate how often you should rebalance to at least break even with the earnings. The lines to the file are only added if the rebalance was successful.

The CSV columns are:
- UNIX timestamp when rebalance succeeded
- from channel short id
- to channel short id
- amount of msats sent
- total fees in msats

This data can be analyzed and aggregated later using shell scripts or more complex programs.